### PR TITLE
Fixing build errors on Linux (CentOS 6.8)

### DIFF
--- a/KParams.h
+++ b/KParams.h
@@ -26,6 +26,7 @@ limitations under the License.
 #define slashdir '\\'
 #else
 #define slashdir '/'
+#include <unistd.h>
 #endif
 
 class KParams {

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ INCLUDE = -I$(MSTOOLKITPATH)/include -I$(HARDKLORPATH)
 
 
 #Do not touch these variables
-KOJAK = KParams.o KAnalysis.o KData.o KDB.o KPrecursor.o KSpectrum.o KIons.o KIonSet.o KTopPeps.o Threading.o
+KOJAK = KParams.o KAnalysis.o KData.o KDB.o KPrecursor.o CometDecoys.o KSpectrum.o KIons.o KIonSet.o KTopPeps.o Threading.o
 
 
 #Make statements
@@ -41,18 +41,21 @@ KDB.o : KDB.cpp
 KPrecursor.o : KPrecursor.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KPrecursor.cpp -c
 
+CometDecoys.o : CometDecoys.cpp
+	$(CC) $(FLAGS) $(INCLUDE) CometDecoys.cpp -c
+
 KSpectrum.o : KSpectrum.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KSpectrum.cpp -c
 
 KIons.o : KIons.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KIons.cpp -c
-		
+
 KIonSet.o : KIonSet.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KIonSet.cpp -c
-	
+
 KTopPeps.o : KTopPeps.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KTopPeps.cpp -c
-		
+
 Threading.o : Threading.cpp
 	$(CC) $(FLAGS) $(INCLUDE) Threading.cpp -c
 


### PR DESCRIPTION
I ran into two errors when trying to build Kojak on CentOS 6.8.

- `'getcwd' was not declared in this scope` from KParams.cpp, line 77, which appears to be Linux-specific. Commit cd0e159 fixes this.  

-  *(You've likely already fixed this one locally)* There was a problem compiling KSpectrum.cpp because CometDecoys.cpp had not been compiled prior. I added this step to the Makefile in commit 6c5f378 and deleted some extra whitespace.   

After making these changes, I was successfully able to build Kojak. 