### PR TITLE
Small changes for Crux integration

### DIFF
--- a/KojakManager.cpp
+++ b/KojakManager.cpp
@@ -1,4 +1,8 @@
 #include "KojakManager.h"
+#include "KAnalysis.h"
+#include "KData.h"
+#include "KDB.h"
+#include "KIons.h"
 
 using namespace std;
 

--- a/KojakManager.h
+++ b/KojakManager.h
@@ -1,10 +1,6 @@
 #ifndef _KOJAKMANAGER_H
 #define _KOJAKMANAGER_H
 
-#include "KAnalysis.h"
-#include "KData.h"
-#include "KDB.h"
-#include "KIons.h"
 #include "KLog.h"
 #include "KParams.h"
 
@@ -34,7 +30,7 @@ private:
   std::string paramFile;
   KParams param_obj;
   kParams params;
-  
+
 };
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ KOJAK = KojakManager.o KParams.o KAnalysis.o KData.o KDB.o KPrecursor.o KSpectru
 kojak : Kojak.cpp $(KOJAK)
 	$(CC) $(FLAGS) $(INCLUDE) $(KOJAK) Kojak.cpp $(LIBPATH) $(LIBS) -o kojak
 
+libkojaksearch.a : $(KOJAK)
+	ar rcs libkojaksearch.a $(KOJAK)
+
 clean:
 	rm *.o kojak
 
@@ -28,7 +31,7 @@ clean:
 #Kojak objects
 KojakManager.o : KojakManager.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KojakManager.cpp -c
-	
+
 KParams.o : KParams.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KParams.cpp -c
 
@@ -49,19 +52,19 @@ KSpectrum.o : KSpectrum.cpp
 
 KIons.o : KIons.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KIons.cpp -c
-		
+
 KIonSet.o : KIonSet.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KIonSet.cpp -c
-	
+
 KLog.o : KLog.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KLog.cpp -c
-	
+
 KTopPeps.o : KTopPeps.cpp
 	$(CC) $(FLAGS) $(INCLUDE) KTopPeps.cpp -c
-		
+
 Threading.o : Threading.cpp
 	$(CC) $(FLAGS) $(INCLUDE) Threading.cpp -c
-	
+
 CometDecoys.o : CometDecoys.cpp
 	$(CC) $(FLAGS) $(INCLUDE) CometDecoys.cpp -c
 


### PR DESCRIPTION
This PR fixes namespace conflicts with Crux and adds a make rule for the `libkojaksearch.a` library used in Crux. Additionally, some extra whitespace was cleaned from the files.